### PR TITLE
feat: format send amount

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -146,7 +146,7 @@ form input.form-control {
 
 form input[type=text]:focus,
 form input[type=password]:focus,
-form input[type=number]:focus {
+form input[type=tel]:focus {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0) !important;
   border: none;
   border-bottom: 1px solid --black;
@@ -154,7 +154,7 @@ form input[type=number]:focus {
 
 form input[type=text]::placeholder,
 form input[type=password]::placeholder,
-form input[type=number]::placeholder {
+form input[type=tel]::placeholder {
   color: --gray300;
 }
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * This file is part of nucleus-wallet.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
+ *
+ * nucleus-wallet is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * nucleus-wallet is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * nucleus-wallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { formatSendAmountInZil } from './utils';
+
+describe('formatSendAmountInZil tests', () => {
+  describe('basic tests', () => {
+    it('int amount and int balance', () => {
+      const result = formatSendAmountInZil('100', '200', '0.001');
+      expect(result).toBe('100');
+    });
+
+    it('float amount and int balance', () => {
+      const result = formatSendAmountInZil('98.999', '99', '0.001');
+      expect(result).toBe('98.999');
+    });
+
+    it('int amount and float balance', () => {
+      const result = formatSendAmountInZil('99', '99.999', '0.001');
+      expect(result).toBe('99');
+    });
+
+    it('float amount and float balance', () => {
+      const result = formatSendAmountInZil('99.000', '99.999', '0.001');
+      expect(result).toBe('99');
+    });
+
+    it('min value test', () => {
+      const result = formatSendAmountInZil('0.000', '100.000', '0.001');
+      expect(result).toBe('0.001');
+    });
+
+    it('max value test', () => {
+      const result = formatSendAmountInZil('1000.000', '100.002', '0.001');
+      expect(result).toBe('100.001');
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License along with
  * nucleus-wallet.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { BN, units } from '@zilliqa-js/util';
 
 export const getInputValidationState = (key: string, value: string, regex: RegExp) => {
   const isInvalid: boolean = regex.test(value);
@@ -35,6 +36,7 @@ export const getInputValidationState = (key: string, value: string, regex: RegEx
     return state;
   }
 };
+
 export const exportToCsv = (filename, rows) => {
   const processRow = (row) => {
     let finalVal = '';
@@ -89,4 +91,24 @@ export const downloadObjectAsJson = (exportObj, exportName) => {
   document.body.appendChild(downloadAnchorNode); // required for firefox
   downloadAnchorNode.click();
   downloadAnchorNode.remove();
+};
+
+export const formatSendAmountInZil = (
+  amountInZil: string,
+  balanceInZil: string,
+  minGasPriceInZil: string
+): string => {
+  const amountInQaBN: BN = units.toQa(amountInZil, units.Units.Zil);
+  const balanceInQaBN: BN = units.toQa(balanceInZil, units.Units.Zil);
+  const minGasPriceInQaBN: BN = units.toQa(minGasPriceInZil, units.Units.Zil);
+
+  const maxAmountInQaBN = balanceInQaBN.sub(minGasPriceInQaBN);
+
+  if (amountInQaBN.lte(minGasPriceInQaBN)) {
+    return units.fromQa(minGasPriceInQaBN, units.Units.Zil).toString();
+  } else if (amountInQaBN.gt(maxAmountInQaBN)) {
+    return units.fromQa(maxAmountInQaBN, units.Units.Zil).toString();
+  } else {
+    return units.fromQa(amountInQaBN, units.Units.Zil).toString();
+  }
 };


### PR DESCRIPTION
**Description**
This PR enhances the amount in the send form by providing the followings
- allows the amount input only if `/^\d*\.?\d*$/`
- formats the amount of ZILs that a user types in to send.
  - if amount < min gas price which is 0.001 ZILs, the amount will be min gas price. 
  - if amount > balance - min gas price, the amount will be balance - min gas price.
  - if min gas price < amount  && amount < balance - min gas price, the amount will be as it is. 