### PR TITLE
feat: autofill address from search params

### DIFF
--- a/src/containers/faucet/index.tsx
+++ b/src/containers/faucet/index.tsx
@@ -26,9 +26,20 @@ import { isBech32 } from '@zilliqa-js/util/dist/validation';
 const FaucetContainer = ({ zilContext }) => {
   const { faucet } = zilContext;
 
-  const [toAddress, setToAddress] = useState('');
-  const [toAddressValid, setToAddressValid] = useState(false);
-  const [toAddressInvalid, setToAddressInvalid] = useState(false);
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const params = Object.fromEntries(urlSearchParams.entries());
+  const initialAddress = params['address'];
+
+  let isInitialAddressValid = false;
+  if (initialAddress !== undefined) {
+    isInitialAddressValid = isBech32(initialAddress);
+  }
+
+  const [toAddress, setToAddress] = useState(initialAddress);
+  const [toAddressValid, setToAddressValid] = useState(isInitialAddressValid);
+  const [toAddressInvalid, setToAddressInvalid] = useState(
+    initialAddress !== undefined && !isInitialAddressValid
+  );
 
   const changeToAddress = (e: React.ChangeEvent<HTMLInputElement>): void => {
     e.preventDefault();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->


This PR autofills address from search params e.g. `https://dev-wallet.zilliqa.com/faucet?address=zil1wltxkuwzzerhe7pnhsqwlt5k590n37j5weqauv`

https://user-images.githubusercontent.com/86328181/128128224-f858f2c1-b83e-40bb-88e9-60a095c541e4.mov



References:
https://github.com/Zilliqa/neo-savant/pull/118
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
